### PR TITLE
Sp 29675 add base uri

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/elimity-com/scim/errors"
 )
@@ -166,7 +165,7 @@ func (s Server) resourcePatchHandler(w http.ResponseWriter, r *http.Request, id 
 		return
 	}
 
-	raw, err := json.Marshal(resource.response(resourceType, s.getBasePath(r, true)))
+	raw, err := json.Marshal(resource.response(resourceType, s.getBasePath(r)))
 	if err != nil {
 		errorHandler(w, r, scimErrorInternalServer)
 		log.Fatalf("failed marshaling resource: %v", err)
@@ -196,7 +195,7 @@ func (s Server) resourcePostHandler(w http.ResponseWriter, r *http.Request, reso
 		return
 	}
 
-	raw, err := json.Marshal(resource.response(resourceType, s.getBasePath(r, true)))
+	raw, err := json.Marshal(resource.response(resourceType, s.getBasePath(r)))
 	if err != nil {
 		errorHandler(w, r, scimErrorInternalServer)
 		log.Fatalf("failed marshaling resource: %v", err)
@@ -218,7 +217,7 @@ func (s Server) resourceGetHandler(w http.ResponseWriter, r *http.Request, id st
 		return
 	}
 
-	raw, err := json.Marshal(resource.response(resourceType, s.getBasePath(r, true)))
+	raw, err := json.Marshal(resource.response(resourceType, s.getBasePath(r)))
 	if err != nil {
 		errorHandler(w, r, scimErrorInternalServer)
 		log.Fatalf("failed marshaling resource: %v", err)
@@ -247,7 +246,7 @@ func (s Server) resourcesGetHandler(w http.ResponseWriter, r *http.Request, reso
 
 	resources := []interface{}{}
 	for _, v := range page.Resources {
-		resources = append(resources, v.response(resourceType, s.getBasePath(r, true)))
+		resources = append(resources, v.response(resourceType, s.getBasePath(r)))
 	}
 
 	raw, err := json.Marshal(listResponse{
@@ -284,7 +283,7 @@ func (s Server) resourcePutHandler(w http.ResponseWriter, r *http.Request, id st
 		return
 	}
 
-	raw, err := json.Marshal(resource.response(resourceType, s.getBasePath(r, true)))
+	raw, err := json.Marshal(resource.response(resourceType, s.getBasePath(r)))
 	if err != nil {
 		errorHandler(w, r, scimErrorInternalServer)
 		log.Fatalf("failed marshaling resource: %v", err)
@@ -307,17 +306,10 @@ func (s Server) resourceDeleteHandler(w http.ResponseWriter, r *http.Request, id
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s Server) getBasePath(r *http.Request, trailingSlash bool) string {
-	if s.Config.BasePathFunc == nil {
+func (s Server) getBasePath(r *http.Request) string {
+	if s.Config.BasePathResolver == nil {
 		return ""
 	}
 
-	basePath := s.Config.BasePathFunc(r)
-
-	basePath = strings.TrimSuffix(basePath, "/")
-	if trailingSlash {
-		basePath += "/"
-	}
-
-	return basePath
+	return s.Config.BasePathResolver(r)
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -3,6 +3,7 @@ package scim
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,8 +13,43 @@ import (
 	"github.com/elimity-com/scim/schema"
 )
 
-func newTestServer() Server {
-	userSchema := schema.Schema{
+func newTestServer(basePath string) Server {
+	userSchema := getUserSchema()
+
+	userSchemaExtension := getUserExtensionSchema()
+
+	return Server{
+		Config: ServiceProviderConfig{
+			BasePathResolver: func(r *http.Request) string {
+				return basePath
+			},
+		},
+		ResourceTypes: []ResourceType{
+			{
+				ID:          optional.NewString("User"),
+				Name:        "User",
+				Endpoint:    "/Users",
+				Description: optional.NewString("User Account"),
+				Schema:      userSchema,
+				Handler:     newTestResourceHandler(),
+			},
+			{
+				ID:          optional.NewString("EnterpriseUser"),
+				Name:        "EnterpriseUser",
+				Endpoint:    "/EnterpriseUser",
+				Description: optional.NewString("Enterprise User Account"),
+				Schema:      userSchema,
+				SchemaExtensions: []SchemaExtension{
+					{Schema: userSchemaExtension},
+				},
+				Handler: newTestResourceHandler(),
+			},
+		},
+	}
+}
+
+func getUserSchema() schema.Schema {
+	return schema.Schema{
 		ID:          "urn:ietf:params:scim:schemas:core:2.0:User",
 		Name:        optional.NewString("User"),
 		Description: optional.NewString("User Account"),
@@ -75,8 +111,10 @@ func newTestServer() Server {
 			}),
 		},
 	}
+}
 
-	userSchemaExtension := schema.Schema{
+func getUserExtensionSchema() schema.Schema {
+	return schema.Schema{
 		ID:          "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
 		Name:        optional.NewString("EnterpriseUser"),
 		Description: optional.NewString("Enterprise User"),
@@ -87,31 +125,6 @@ func newTestServer() Server {
 			schema.SimpleCoreAttribute(schema.SimpleStringParams(schema.StringParams{
 				Name: "organization",
 			})),
-		},
-	}
-
-	return Server{
-		Config: ServiceProviderConfig{},
-		ResourceTypes: []ResourceType{
-			{
-				ID:          optional.NewString("User"),
-				Name:        "User",
-				Endpoint:    "/Users",
-				Description: optional.NewString("User Account"),
-				Schema:      userSchema,
-				Handler:     newTestResourceHandler(),
-			},
-			{
-				ID:          optional.NewString("EnterpriseUser"),
-				Name:        "EnterpriseUser",
-				Endpoint:    "/EnterpriseUser",
-				Description: optional.NewString("Enterprise User Account"),
-				Schema:      userSchema,
-				SchemaExtensions: []SchemaExtension{
-					{Schema: userSchemaExtension},
-				},
-				Handler: newTestResourceHandler(),
-			},
 		},
 	}
 }
@@ -132,199 +145,468 @@ func newTestResourceHandler() ResourceHandler {
 }
 
 func TestInvalidEndpoint(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/v2/Invalid", nil)
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	tests := []struct {
+		name           string
+		method         string
+		basePath       string
+		target         string
+		body           io.Reader
+		expectedStatus int
+	}{
+		{
+			name:           "invalid get request, no base path",
+			method:         http.MethodGet,
+			target:         "/v2/Invalid",
+			expectedStatus: http.StatusNotFound,
+		}, {
+			name:           "invalid get request, with base path",
+			method:         http.MethodGet,
+			basePath:       "/my/test/base/path",
+			target:         "/my/test/base/path/v2/Invalid",
+			expectedStatus: http.StatusNotFound,
+		}, {
+			name:           "invalid get request, outside base path",
+			method:         http.MethodGet,
+			basePath:       "my/test/base/path/v2",
+			target:         "/v2/Invalid",
+			expectedStatus: http.StatusNotFound,
+		}, {
+			name:           "invalid schema request, no base path",
+			method:         http.MethodGet,
+			target:         "/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group",
+			expectedStatus: http.StatusNotFound,
+		}, {
+			name:           "invalid schema request, with base path",
+			method:         http.MethodGet,
+			basePath:       "/my/test/base/path",
+			target:         "/my/test/base/path/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group",
+			expectedStatus: http.StatusNotFound,
+		}, {
+			name:           "invalid resource types request, no base path",
+			method:         http.MethodGet,
+			target:         "/ResourceTypes/Group",
+			expectedStatus: http.StatusNotFound,
+		}, {
+			name:           "invalid resource types request, with base path",
+			method:         http.MethodGet,
+			basePath:       "/my/test/base/path",
+			target:         "/my/test/base/path/ResourceTypes/Group",
+			expectedStatus: http.StatusNotFound,
+		}, {
+			name:           "invalid post request, no base path",
+			method:         http.MethodPost,
+			target:         "/Users",
+			body:           strings.NewReader(`{"id": "other"}`),
+			expectedStatus: http.StatusBadRequest,
+		}, {
+			name:           "invalid post request, with base path",
+			method:         http.MethodPost,
+			basePath:       "/my/test/base/path",
+			target:         "/my/test/base/path/Users",
+			body:           strings.NewReader(`{"id": "other"}`),
+			expectedStatus: http.StatusBadRequest,
+		}, {
+			name:           "invalid put request, no base path",
+			method:         http.MethodPut,
+			target:         "/Users/0001",
+			body:           strings.NewReader(`{"more": "test"}`),
+			expectedStatus: http.StatusBadRequest,
+		}, {
+			name:           "invalid put request, with base path",
+			method:         http.MethodPut,
+			basePath:       "/my/test/base/path",
+			target:         "/my/test/base/path/Users/0001",
+			body:           strings.NewReader(`{"more": "test"}`),
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
 
-	if status := rr.Code; status != http.StatusNotFound {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusNotFound)
+	for _, tt := range tests {
+		tt := tt // scopelint
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.target, nil)
+			rr := httptest.NewRecorder()
+			newTestServer(tt.basePath).ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tt.expectedStatus {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, tt.expectedStatus)
+			}
+		})
 	}
 }
 
 func TestServerSchemasEndpoint(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/Schemas", nil)
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
-
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	tests := []struct {
+		name     string
+		basePath string
+		target   string
+	}{
+		{
+			name:   "schemas request without version",
+			target: "/Schemas",
+		}, {
+			name:   "schemas request with version",
+			target: "/v2/Schemas",
+		}, {
+			name:     "schemas request without version, with base path",
+			basePath: "/my/test/base/path",
+			target:   "/my/test/base/path/Schemas",
+		}, {
+			name:     "schemas request with version, with base path",
+			basePath: "/my/test/base/path",
+			target:   "/my/test/base/path/v2/Schemas",
+		},
 	}
 
-	var response listResponse
-	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
-		t.Error(err)
+	for _, tt := range tests {
+		tt := tt // scopelint
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			rr := httptest.NewRecorder()
+			newTestServer(tt.basePath).ServeHTTP(rr, req)
+
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+			}
+
+			var response listResponse
+			if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+				t.Error(err)
+			}
+
+			if response.TotalResults != 2 {
+				t.Errorf("handler returned unexpected body: got %v want 2 total result", rr.Body.String())
+			}
+
+			if len(response.Resources) != 2 {
+				t.Fatal("resources contains more than one schema")
+			}
+
+			s, ok := response.Resources[0].(map[string]interface{})
+			if !ok {
+				t.Fatal("schema is not an object")
+			}
+
+			if s["id"].(string) != "urn:ietf:params:scim:schemas:core:2.0:User" &&
+				s["id"].(string) != "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User" {
+				t.Errorf("schema does not contain the correct id: %v", s["id"])
+			}
+		})
 	}
-
-	if response.TotalResults != 2 {
-		t.Errorf("handler returned unexpected body: got %v want 2 total result", rr.Body.String())
-	}
-
-	if len(response.Resources) != 2 {
-		t.Fatal("resources contains more than one schema")
-	}
-
-	s, ok := response.Resources[0].(map[string]interface{})
-	if !ok {
-		t.Fatal("schema is not an object")
-	}
-
-	if s["id"].(string) != "urn:ietf:params:scim:schemas:core:2.0:User" &&
-		s["id"].(string) != "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User" {
-		t.Errorf("schema does not contain the correct id: %v", s["id"])
-	}
-}
-
-func TestServerSchemaEndpointInvalid(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group", nil)
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
-
-	if status := rr.Code; status != http.StatusNotFound {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusNotFound)
-	}
-
 }
 
 func TestServerSchemaEndpointValid(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/Schemas/urn:ietf:params:scim:schemas:core:2.0:User", nil)
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
-
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	tests := []struct {
+		name     string
+		basePath string
+		schema   string
+	}{
+		{
+			name:   "User schema",
+			schema: "urn:ietf:params:scim:schemas:core:2.0:User",
+		}, {
+			name:   "Enterprice user schema",
+			schema: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+		}, {
+			name:     "User schema, with base path",
+			schema:   "urn:ietf:params:scim:schemas:core:2.0:User",
+			basePath: "/my/test/base/path",
+		}, {
+			name:     "Enterprice user schema, with base path",
+			schema:   "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+			basePath: "/my/test/base/path",
+		},
 	}
 
-	var s map[string]interface{}
-	if err := json.Unmarshal(rr.Body.Bytes(), &s); err != nil {
-		t.Fatal(err)
-	}
+	for _, tt := range tests {
+		tt := tt // scopelint
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("%s/Schemas/%s", tt.basePath, tt.schema), nil)
+			rr := httptest.NewRecorder()
+			newTestServer(tt.basePath).ServeHTTP(rr, req)
 
-	if s["id"].(string) != "urn:ietf:params:scim:schemas:core:2.0:User" {
-		t.Errorf("schema does not contain the correct id: %s", s["id"])
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+			}
+
+			var s map[string]interface{}
+			if err := json.Unmarshal(rr.Body.Bytes(), &s); err != nil {
+				t.Fatal(err)
+			}
+
+			if s["id"].(string) != tt.schema {
+				t.Errorf("schema does not contain the correct id: %s", s["id"])
+			}
+		})
 	}
 }
 
 func TestServerResourceTypesHandler(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/ResourceTypes", nil)
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
-
-	if status := rr.Code; status != http.StatusOK {
-		t.Fatalf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	tests := []struct {
+		name     string
+		basePath string
+		target   string
+	}{
+		{
+			name:   "resource types request without version",
+			target: "/ResourceTypes",
+		}, {
+			name:   "resource types request with version",
+			target: "/v2/ResourceTypes",
+		}, {
+			name:     "resource types request without version, with base path",
+			basePath: "/my/test/base/path",
+			target:   "/my/test/base/path/ResourceTypes",
+		}, {
+			name:     "resource types request with version, with base path",
+			basePath: "/my/test/base/path",
+			target:   "/my/test/base/path/v2/ResourceTypes",
+		},
 	}
 
-	var response listResponse
-	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
-		t.Fatal(err)
-	}
+	for _, tt := range tests {
+		tt := tt // scopelint
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			rr := httptest.NewRecorder()
+			newTestServer(tt.basePath).ServeHTTP(rr, req)
 
-	if response.TotalResults != 2 {
-		t.Errorf("handler returned unexpected body: got %v want 1 total result", rr.Body.String())
-	}
+			if status := rr.Code; status != http.StatusOK {
+				t.Fatalf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+			}
 
-	if len(response.Resources) != 2 {
-		t.Fatal("resources contains more than one schema")
-	}
+			var response listResponse
+			if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+				t.Fatal(err)
+			}
 
-	resourceType, ok := response.Resources[0].(map[string]interface{})
-	if !ok {
-		t.Errorf("resource type is not an object")
-	}
+			if response.TotalResults != 2 {
+				t.Errorf("handler returned unexpected body: got %v want 1 total result", rr.Body.String())
+			}
 
-	if resourceType["name"].(string) != "User" &&
-		resourceType["name"].(string) != "EnterpriseUser" {
-		t.Errorf("schema does not contain the correct id: %v", resourceType["name"])
-	}
-}
+			if len(response.Resources) != 2 {
+				t.Fatal("resources contains more than one schema")
+			}
 
-func TestServerResourceTypeHandlerInvalid(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/ResourceTypes/Group", nil)
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+			resourceType, ok := response.Resources[0].(map[string]interface{})
+			if !ok {
+				t.Errorf("resource type is not an object")
+			}
 
-	if status := rr.Code; status != http.StatusNotFound {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusNotFound)
+			if resourceType["name"].(string) != "User" &&
+				resourceType["name"].(string) != "EnterpriseUser" {
+				t.Errorf("schema does not contain the correct id: %v", resourceType["name"])
+			}
+		})
 	}
 }
 
 func TestServerResourceTypeHandlerValid(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/ResourceTypes/User", nil)
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
-
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	tests := []struct {
+		name         string
+		basePath     string
+		resourceType string
+	}{
+		{
+			name:         "User schema",
+			resourceType: "User",
+		}, {
+			name:         "Enterprice user schema",
+			resourceType: "EnterpriseUser",
+		}, {
+			name:         "User schema, with base path",
+			resourceType: "User",
+			basePath:     "/my/test/base/path",
+		}, {
+			name:         "Enterprice user schema, with base path",
+			resourceType: "EnterpriseUser",
+			basePath:     "/my/test/base/path",
+		},
 	}
 
-	var resourceType map[string]interface{}
-	if err := json.Unmarshal(rr.Body.Bytes(), &resourceType); err != nil {
-		t.Fatal(err)
-	}
-	if resourceType["id"] != "User" {
-		t.Errorf("schema does not contain the correct name: %s", resourceType["name"])
+	for _, tt := range tests {
+		tt := tt // scopelint
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("%s/ResourceTypes/%s", tt.basePath, tt.resourceType), nil)
+			rr := httptest.NewRecorder()
+			newTestServer(tt.basePath).ServeHTTP(rr, req)
+
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+			}
+
+			var resourceType map[string]interface{}
+			if err := json.Unmarshal(rr.Body.Bytes(), &resourceType); err != nil {
+				t.Fatal(err)
+			}
+			if resourceType["id"] != tt.resourceType {
+				t.Errorf("schema does not contain the correct name: %s", resourceType["name"])
+			}
+		})
 	}
 }
 
 func TestServerServiceProviderConfigHandler(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/ServiceProviderConfig", nil)
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
-
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	tests := []struct {
+		name     string
+		basePath string
+		target   string
+	}{
+		{
+			name:   "service provide config request without version",
+			target: "/ServiceProviderConfig",
+		}, {
+			name:   "service provide config request with version",
+			target: "/v2/ServiceProviderConfig",
+		}, {
+			name:     "service provide config request without version, with base path",
+			basePath: "/my/test/base/path",
+			target:   "/my/test/base/path/ServiceProviderConfig",
+		}, {
+			name:     "service provide config request with version, with base path",
+			basePath: "/my/test/base/path",
+			target:   "/my/test/base/path/v2/ServiceProviderConfig",
+		},
 	}
-}
 
-func TestServerResourcePostHandlerInvalid(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/Users", strings.NewReader(`{"id": "other"}`))
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	for _, tt := range tests {
+		tt := tt // scopelint
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			rr := httptest.NewRecorder()
+			newTestServer(tt.basePath).ServeHTTP(rr, req)
 
-	if status := rr.Code; status != http.StatusBadRequest {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusBadRequest)
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+			}
+		})
 	}
 }
 
 func TestServerResourcePostHandlerValid(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/Users", strings.NewReader(`{"id": "other", "userName": "test1"}`))
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
-
-	if status := rr.Code; status != http.StatusCreated {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusCreated)
+	tests := []struct {
+		name             string
+		basePath         string
+		target           string
+		body             io.Reader
+		expectedUserName string
+	}{
+		{
+			name:             "Users post request without version",
+			target:           "/Users",
+			body:             strings.NewReader(`{"id": "other", "userName": "test1"}`),
+			expectedUserName: "test1",
+		}, {
+			name:             "Users post request with version",
+			target:           "/v2/Users",
+			body:             strings.NewReader(`{"id": "other", "userName": "test2"}`),
+			expectedUserName: "test2",
+		}, {
+			name:             "Users post request without version, with base path",
+			basePath:         "/my/test/base/path",
+			target:           "/my/test/base/path/Users",
+			body:             strings.NewReader(`{"id": "other", "userName": "test3"}`),
+			expectedUserName: "test3",
+		}, {
+			name:             "Users post request with version, with base path",
+			basePath:         "/my/test/base/path",
+			target:           "/my/test/base/path/v2/Users",
+			body:             strings.NewReader(`{"id": "other", "userName": "test4"}`),
+			expectedUserName: "test4",
+		},
 	}
 
-	var resource map[string]interface{}
-	if err := json.Unmarshal(rr.Body.Bytes(), &resource); err != nil {
-		t.Fatal(err)
-	}
-	if resource["userName"] != "test1" {
-		t.Error("handler did not return the resource correctly")
+	for _, tt := range tests {
+		tt := tt // scopelint
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.target, tt.body)
+			rr := httptest.NewRecorder()
+			newTestServer(tt.basePath).ServeHTTP(rr, req)
+
+			if status := rr.Code; status != http.StatusCreated {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusCreated)
+			}
+
+			var resource map[string]interface{}
+			if err := json.Unmarshal(rr.Body.Bytes(), &resource); err != nil {
+				t.Fatal(err)
+			}
+			if resource["userName"] != tt.expectedUserName {
+				t.Error("handler did not return the resource correctly")
+			}
+		})
 	}
 }
 
 func TestServerResourceGetHandler(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/Users/0001", nil)
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
 
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	tests := []struct {
+		name             string
+		basePath         string
+		target           string
+		expectedUserName string
+	}{
+		{
+			name:             "Users get request without version",
+			target:           "/Users/0001",
+			expectedUserName: "test1",
+		}, {
+			name:             "Users get request with version",
+			target:           "/v2/Users/0002",
+			expectedUserName: "test2",
+		}, {
+			name:             "Users get request without version, with base path",
+			basePath:         "/my/test/base/path",
+			target:           "/my/test/base/path/Users/0003",
+			expectedUserName: "test3",
+		}, {
+			name:             "Users get request with version, with base path",
+			basePath:         "/my/test/base/path",
+			target:           "/my/test/base/path/v2/Users/0004",
+			expectedUserName: "test4",
+		},
 	}
 
-	var resource map[string]interface{}
-	if err := json.Unmarshal(rr.Body.Bytes(), &resource); err != nil {
-		t.Fatal(err)
-	}
-	if resource["userName"] != "test1" {
-		t.Error("handler did not return the resource correctly")
+	for _, tt := range tests {
+		tt := tt // scopelint
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			rr := httptest.NewRecorder()
+			newTestServer(tt.basePath).ServeHTTP(rr, req)
+
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+			}
+
+			var resource map[string]interface{}
+			if err := json.Unmarshal(rr.Body.Bytes(), &resource); err != nil {
+				t.Fatal(err)
+			}
+
+			if resource["userName"] != tt.expectedUserName {
+				t.Error("handler did not return the resource correctly")
+			}
+
+			meta, ok := resource["meta"].(map[string]interface{})
+			if !ok {
+				t.Error("handler did not return the resource meta correctly")
+			}
+
+			if meta["resourceType"] != "User" {
+				t.Error("handler did not return the resource meta resource type correctly")
+			}
+
+			if meta["location"] != strings.TrimPrefix(fmt.Sprintf("%s/Users/%s", tt.basePath, resource["id"]), "/") {
+				t.Error("handler did not return the resource meta location correctly", meta["location"])
+			}
+		})
 	}
 }
 
 func TestServerResourceGetHandlerNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/Users/9999", nil)
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusNotFound {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusNotFound)
@@ -342,7 +624,7 @@ func TestServerResourceGetHandlerNotFound(t *testing.T) {
 func TestServerResourcesGetHandler(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/Users", nil)
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
@@ -361,7 +643,7 @@ func TestServerResourcesGetHandler(t *testing.T) {
 func TestServerResourcesGetHandlerPagination(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/Users?count=2&startIndex=2", nil)
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
@@ -380,7 +662,7 @@ func TestServerResourcesGetHandlerPagination(t *testing.T) {
 func TestServerResourcesGetHandlerMaxCount(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/Users?count=20000", nil)
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
@@ -424,7 +706,7 @@ func TestServerResourcePatchHandlerValid(t *testing.T) {
 		]
 	}`))
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	var resource map[string]interface{}
 	if err := json.Unmarshal(rr.Body.Bytes(), &resource); err != nil {
@@ -461,7 +743,7 @@ func TestServerResourcePatchHandlerFailOnBadType(t *testing.T) {
 		]
 	}`))
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	var resource map[string]interface{}
 	if err := json.Unmarshal(rr.Body.Bytes(), &resource); err != nil {
@@ -487,7 +769,7 @@ func TestServerResourcePatchHandlerFailOnUndefinedAttribute(t *testing.T) {
 		]
 	}`))
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	var resource map[string]interface{}
 	if err := json.Unmarshal(rr.Body.Bytes(), &resource); err != nil {
@@ -512,7 +794,7 @@ func runPatchImmutableTest(t *testing.T, op, path string, expectedStatus int) {
 		]
 	}`, op, path)))
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	var resource map[string]interface{}
 	if err := json.Unmarshal(rr.Body.Bytes(), &resource); err != nil {
@@ -535,20 +817,10 @@ func TestServerResourcePatchHandlerFailOnImmutable(t *testing.T) {
 	runPatchImmutableTest(t, PatchOperationReplace, "readonlyThing", http.StatusBadRequest)
 }
 
-func TestServerResourcePutHandlerInvalid(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPut, "/Users/0001", strings.NewReader(`{"more": "test"}`))
-	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
-
-	if status := rr.Code; status != http.StatusBadRequest {
-		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusBadRequest)
-	}
-}
-
 func TestServerResourcePutHandlerValid(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "/Users/0001", strings.NewReader(`{"id": "test", "userName": "other"}`))
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
@@ -566,7 +838,7 @@ func TestServerResourcePutHandlerValid(t *testing.T) {
 func TestServerResourcePutHandlerNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "/Users/9999", strings.NewReader(`{"userName": "other"}`))
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusNotFound {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusNotFound)
@@ -585,7 +857,7 @@ func TestServerResourcePutHandlerNotFound(t *testing.T) {
 func TestServerResourceDeleteHandler(t *testing.T) {
 	req := httptest.NewRequest(http.MethodDelete, "/Users/0001", nil)
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusNoContent {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusNoContent)
@@ -595,7 +867,7 @@ func TestServerResourceDeleteHandler(t *testing.T) {
 func TestServerResourceDeleteHandlerNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodDelete, "/Users/9999", nil)
 	rr := httptest.NewRecorder()
-	newTestServer().ServeHTTP(rr, req)
+	newTestServer("").ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusNotFound {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusNotFound)

--- a/resource_handler.go
+++ b/resource_handler.go
@@ -35,7 +35,7 @@ type Resource struct {
 	Attributes ResourceAttributes
 }
 
-func (r Resource) response(resourceType ResourceType) ResourceAttributes {
+func (r Resource) response(resourceType ResourceType, basePath string) ResourceAttributes {
 	response := r.Attributes
 	response["id"] = r.ID
 	schemas := []string{resourceType.Schema.ID}
@@ -45,7 +45,7 @@ func (r Resource) response(resourceType ResourceType) ResourceAttributes {
 	response["schemas"] = schemas
 	response["meta"] = meta{
 		ResourceType: resourceType.Name,
-		Location:     fmt.Sprintf("%s/%s", resourceType.Endpoint[1:], url.PathEscape(r.ID)),
+		Location:     fmt.Sprintf("%s%s/%s", basePath, resourceType.Endpoint[1:], url.PathEscape(r.ID)),
 	}
 
 	return response

--- a/resource_handler.go
+++ b/resource_handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	scim "github.com/di-wu/scim-filter-parser"
 	"github.com/elimity-com/scim/errors"
@@ -42,6 +43,11 @@ func (r Resource) response(resourceType ResourceType, basePath string) ResourceA
 	for _, schema := range resourceType.SchemaExtensions {
 		schemas = append(schemas, schema.Schema.ID)
 	}
+
+	if len(basePath) > 0 {
+		basePath = strings.TrimSuffix(basePath[1:], "/") + "/"
+	}
+
 	response["schemas"] = schemas
 	response["meta"] = meta{
 		ResourceType: resourceType.Name,

--- a/server.go
+++ b/server.go
@@ -62,7 +62,7 @@ func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/scim+json")
 
 	path := r.URL.Path
-	basePath := s.getBasePath(r, false)
+	basePath := strings.TrimSuffix(s.getBasePath(r), "/")
 
 	if !strings.HasPrefix(path, basePath) {
 		errorHandler(w, r, scimError{

--- a/server.go
+++ b/server.go
@@ -60,7 +60,23 @@ func (s Server) getSchema(id string) schema.Schema {
 // ServeHTTP dispatches the request to the handler whose pattern most closely matches the request URL.
 func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/scim+json")
-	path := strings.TrimPrefix(r.URL.Path, "/v2")
+
+	path := r.URL.Path
+	basePath := s.getBasePath(r, false)
+
+	if !strings.HasPrefix(path, basePath) {
+		errorHandler(w, r, scimError{
+			detail: "Specified endpoint does not exist.",
+			status: http.StatusNotFound,
+		})
+
+		return
+	}
+
+	path = strings.TrimPrefix(path, basePath)
+	// Keeping this for backwards compatible reasons
+	path = strings.TrimPrefix(path, "/v2")
+
 	switch {
 	case path == "/Schemas" && r.Method == http.MethodGet:
 		s.schemasHandler(w, r)

--- a/service_provider_config.go
+++ b/service_provider_config.go
@@ -1,6 +1,8 @@
 package scim
 
 import (
+	"net/http"
+
 	"github.com/elimity-com/scim/optional"
 )
 
@@ -10,6 +12,9 @@ type ServiceProviderConfig struct {
 	// DocumentationURI is an HTTP-addressable URL pointing to the service provider's human-consumable help
 	// documentation.
 	DocumentationURI optional.String
+	// BasePathFunc is used to be able to handle requests with a common prefix for the exposed endpoints
+	// (Schema, ResourceTypes, ServiceProviderConfig & configured ResourceType endpoints.)
+	BasePathFunc func(r *http.Request) string
 	// AuthenticationSchemes is a multi-valued complex type that specifies supported authentication scheme properties.
 	AuthenticationSchemes []AuthenticationScheme
 	// MaxResults denotes the the integer value specifying the maximum number of resources returned in a response. It defaults to 100.

--- a/service_provider_config.go
+++ b/service_provider_config.go
@@ -12,9 +12,9 @@ type ServiceProviderConfig struct {
 	// DocumentationURI is an HTTP-addressable URL pointing to the service provider's human-consumable help
 	// documentation.
 	DocumentationURI optional.String
-	// BasePathFunc is used to be able to handle requests with a common prefix for the exposed endpoints
+	// BasePathResolver is used to be able to handle requests with a common prefix for the exposed endpoints
 	// (Schema, ResourceTypes, ServiceProviderConfig & configured ResourceType endpoints.)
-	BasePathFunc func(r *http.Request) string
+	BasePathResolver func(r *http.Request) string
 	// AuthenticationSchemes is a multi-valued complex type that specifies supported authentication scheme properties.
 	AuthenticationSchemes []AuthenticationScheme
 	// MaxResults denotes the the integer value specifying the maximum number of resources returned in a response. It defaults to 100.


### PR DESCRIPTION
We should be able to handle Schema, ResourceTypes, ServiceProviderConfig requests with the same prefix as the resourceTypes.

We also want to make it possible to use the same handlers even if different entry points are used
(Scim service is running behind a proxy)